### PR TITLE
put gravity by radius - avoid overlooking one or other

### DIFF
--- a/vulcan_cfg.py
+++ b/vulcan_cfg.py
@@ -40,6 +40,7 @@ use_photo = True
 # astronomy input
 r_star = 0.805 # stellar radius in solar radius
 Rp = 1.138*7.1492E9 # Planetary radius (cm) (for computing gravity)
+gs = 2140.         # surface gravity (cm/s^2)  (HD189:2140  HD209:936)
 orbit_radius = 0.03142 # planet-star distance in A.U.
 sl_angle = 58 /180.*3.14159 # the zenith angle of the star in degree (usually 58 deg for the dayside average)
 f_diurnal = 1. # to account for the diurnal average of solar flux (i.e. 0.5 for Earth; 1 for tidally-locked planets) 
@@ -76,7 +77,6 @@ Kzz_prof = 'Pfunc' # Options: 'const','file' or 'Pfunc' (Kzz increased with P^-0
 K_max = 1e5        # for Kzz_prof = 'Pfunc'
 K_p_lev = 0.1      # for Kzz_prof = 'Pfunc'
 vz_prof = 'const'  # Options: 'const' or 'file'
-gs = 2140.         # surface gravity (cm/s^2)  (HD189:2140  HD209:936)
 Tiso = 1000 # only read when atm_type = 'isothermal'
 # setting the parameters for the analytical T-P from (126)in Heng et al. 2014. Only reads when atm_type = 'analytical' 
 # T_int, T_irr, ka_L, ka_S, beta_S, beta_L


### PR DESCRIPTION
In CFG file, move 'gs' (planet gravity) next to 'Rp' (planet radius). At present they are far apart from each other in the file, making it easy to overlook changing one or the other (like I recently did!).